### PR TITLE
Remove Absolute Element Workaround (soon)

### DIFF
--- a/src/sscr.js
+++ b/src/sscr.js
@@ -167,6 +167,7 @@ function init() {
 
         observer = new MutationObserver(refresh);
         observer.observe(body, config);
+        window.addEventListener('resize', refresh);
 
         if (root.offsetHeight <= windowHeight) {
             var clearfix = document.createElement('div');   


### PR DESCRIPTION
While working on a website I noticed a strange space was sometimes being added after the footer at the bottom of the page. I then found out this addon was the source of the problem. It sometimes adds a big, absolutely positioned element, needed to fix a bug according to comments in the code. It has MutationObserver, but when a media query changes an element's height, it's not triggered. I have a test case where the height of an element changes, scrollHeight changes with it, MutationObserver is not triggered, refresh is not called, the element's height is no longer correct and the page breaks.

In most situations the content in a webpage only grows or stays the same, and I suppose that's the reason why this wasn't found first. In my case however it shrinks, because there is a big textarea in the center, and its height is adjusted to maintain the aspect ratio when the user changes the width of the browser. I guess you could have other situations when resizing the window changed the font-size and the height of the whole page with it. The important part here is that there are ways of modifying it without changing the DOM.

I made a [test](https://rawgit.com/KillerJK/9c258769f66c6a820f3d/raw/421fdf297a50896e19c9693d090deb220d13515c/bug-footer.html) to show exactly what happens. Load the webpage with a wide window, then shrink it to trigger the media query, and look at the footer.

I didn't want to submit a bug report without at least trying to understand what was going on, but I don't know if you will like the very simple patch. I tried to find a way to trigger an event only when scrollHeight was modified, but I couldn't find anything other than observing attributes and the dom (which is not what I want).

Because the handler is in a 500ms timeout, it doesn't seem to affect performance. You can however still see how the footer is adjusted soon after the resize, and its ugly. You may want to increase the frequency, 500ms seems a very relaxed number for the work done by the handler. To be sure, you may want to profile it. If it's slow, maybe checking if a height change is necessary instead of always setting a new one.

Anyway, my primary goal was making sure you were aware of this problem.

Awesome extension!
